### PR TITLE
LP-3: Increase default size of AvatarImg

### DIFF
--- a/src/components/AvatarList.tsx
+++ b/src/components/AvatarList.tsx
@@ -13,7 +13,7 @@ type MyProps = {
 const AvatarList: React.FC<MyProps> = ({
   userList,
   getDotColor,
-  imgSize = 'small',
+  imgSize = 'medium',
   showPlaceholder,
   onClick,
 }) => {

--- a/src/pages/meeting/Ticket.tsx
+++ b/src/pages/meeting/Ticket.tsx
@@ -150,7 +150,6 @@ const Ticket: React.FunctionComponent<MyProps> = ({
 
       <div className="mx-1">
         <AvatarList
-          imgSize="small"
           userList={voterList}
           getDotColor={id => (t.votes[id] === undefined ? 'bg-red-1' : '')}
         />


### PR DESCRIPTION
* Increased on Ticket cards and Meeting cards
* Remains the same size in the header